### PR TITLE
Ensure each ActiveDirectory::User attribute has a value

### DIFF
--- a/lib/Auth/ActiveDirectory.pm
+++ b/lib/Auth/ActiveDirectory.pm
@@ -126,23 +126,29 @@ sub authenticate {
         return;
     }
 
-    my $result = $self->_search_users( qq/(&(objectClass=person)(userPrincipalName=$user./ . $self->principal . '))' );
+    my $result = $self->_search_users(
+        qq/(&(objectClass=person)(userPrincipalName=$user./ . $self->principal . '))' );
     foreach ( $result->entries ) {
         require Auth::ActiveDirectory::Group;
         require Auth::ActiveDirectory::User;
         return Auth::ActiveDirectory::User->new(
-            uid               => $username,
-            user              => $user,
-            firstname         => $_->get_value(q/givenName/),
-            surname           => $_->get_value(q/sn/),
-            display_name      => $_->get_value(q/displayName/),
-            mail              => $_->get_value(q/mail/),
+            uid               => scalar($username),
+            user              => scalar($user),
+            firstname         => scalar( $_->get_value(q/givenName/) ),
+            surname           => scalar( $_->get_value(q/sn/) ),
+            display_name      => scalar( $_->get_value(q/displayName/) ),
+            mail              => scalar( $_->get_value(q/mail/) ),
             last_password_set => _ad2unixtimestamp( $_->get_value('pwdLastSet') ),
 
             # A value of 0 or 0x7FFFFFFFFFFFFFFF (9223372036854775807) indicates that the account never expires.
             # https://msdn.microsoft.com/en-us/library/ms675098(v=vs.85).aspx
-            account_expires => ( $_->get_value('accountExpires') != 9223372036854775807 ) ? _ad2unixtimestamp( $_->get_value('accountExpires') ) : undef,
-            groups => [ map { m/^CN=(.*),OU=.*$/ ? Auth::ActiveDirectory::Group->new( name => $1 ) : () } $_->get_value(q/memberOf/) ],
+            account_expires => ( scalar( $_->get_value('accountExpires') ) != 9223372036854775807 )
+                ? _ad2unixtimestamp( scalar( $_->get_value('accountExpires') ) )
+                : undef,
+            groups => [
+                map { m/^CN=(.*),OU=.*$/ ? Auth::ActiveDirectory::Group->new( name => $1 ) : () }
+                    $_->get_value(q/memberOf/)
+            ],
 
         );
     }
@@ -162,7 +168,14 @@ sub list_users {
         return;
     }
     my $result = $self->_search_users(qq/(&(objectClass=person)(name=$search_string*))/);
-    return [ map { Auth::ActiveDirectory::User->new( name => $_->get_value(q/name/), uid => $_->get_value(q/sAMAccountName/) ) } $result->entries ];
+    return [
+        map {
+            Auth::ActiveDirectory::User->new(
+                name => scalar( $_->get_value(q/name/) ),
+                uid  => scalar( $_->get_value(q/sAMAccountName/) )
+                )
+        } $result->entries
+    ];
 }
 
 =head2 host
@@ -279,7 +292,7 @@ __END__
 
     # returns object from logged in user or undef if it fails
     my $user = $obj->authenticate( $args{username}, $args{password} );
-    
+
 
 =head1 AUTHOR
 

--- a/lib/Auth/ActiveDirectory.pm
+++ b/lib/Auth/ActiveDirectory.pm
@@ -132,18 +132,18 @@ sub authenticate {
         require Auth::ActiveDirectory::Group;
         require Auth::ActiveDirectory::User;
         return Auth::ActiveDirectory::User->new(
-            uid               => scalar($username),
-            user              => scalar($user),
-            firstname         => scalar( $_->get_value(q/givenName/) ),
-            surname           => scalar( $_->get_value(q/sn/) ),
-            display_name      => scalar( $_->get_value(q/displayName/) ),
-            mail              => scalar( $_->get_value(q/mail/) ),
+            uid               => $username,
+            user              => $user,
+            firstname         => scalar $_->get_value(q/givenName/),
+            surname           => scalar $_->get_value(q/sn/),
+            display_name      => scalar $_->get_value(q/displayName/),
+            mail              => scalar $_->get_value(q/mail/),
             last_password_set => _ad2unixtimestamp( $_->get_value('pwdLastSet') ),
 
             # A value of 0 or 0x7FFFFFFFFFFFFFFF (9223372036854775807) indicates that the account never expires.
             # https://msdn.microsoft.com/en-us/library/ms675098(v=vs.85).aspx
-            account_expires => ( scalar( $_->get_value('accountExpires') ) != 9223372036854775807 )
-                ? _ad2unixtimestamp( scalar( $_->get_value('accountExpires') ) )
+            account_expires => ( scalar $_->get_value('accountExpires') != 9223372036854775807 )
+                ? _ad2unixtimestamp( scalar $_->get_value('accountExpires') )
                 : undef,
             groups => [
                 map { m/^CN=(.*),OU=.*$/ ? Auth::ActiveDirectory::Group->new( name => $1 ) : () }
@@ -171,9 +171,9 @@ sub list_users {
     return [
         map {
             Auth::ActiveDirectory::User->new(
-                name => scalar( $_->get_value(q/name/) ),
-                uid  => scalar( $_->get_value(q/sAMAccountName/) )
-                )
+                name => scalar $_->get_value(q/name/),
+                uid  => scalar $_->get_value(q/sAMAccountName/)
+            )
         } $result->entries
     ];
 }


### PR DESCRIPTION
If an attribute is not present within the LDAP search entry then  an empty array can be passed which breaks the key/value pattern.

Net::LDAP::Entry get_value has a wantarray ? @_ : $_[0] pattern within it.

If it is used within an array context (as in the Auth::ActiveDirectory::User->new() call) then it can return other than a single item, which breaks the constructor.

Fixes #2
